### PR TITLE
Continue training

### DIFF
--- a/hunvec/feature/featurizer.py
+++ b/hunvec/feature/featurizer.py
@@ -31,35 +31,42 @@ def last_but_ones(x):
 def last_but_twos(x):
     return snf(x, 3, -2)
 
+
 def gazetteer_feat(x, name='', set_=([])):
     if x.lower() in set_:
         return '1_{0}'.format(name)
     else:
         return '0_{0}'.format(name)
 
+gaz_fns = {
+    'languages': '/home/eszter/CIA_lists/misc/languages.txt',
+    'religion': '/home/eszter/CIA_lists/misc/religion.txt',
+    'ethnic': '/home/eszter/CIA_lists/misc/ethnic.txt',
+    'nationality': '/home/eszter/CIA_lists/misc/nationality.txt',
+    'capital': '/home/eszter/CIA_lists/loc/capital.txt',
+    'city': '/home/eszter/CIA_lists/loc/city.txt',
+    'country': '/home/eszter/CIA_lists/loc/countries.txt',
+    'port': '/home/eszter/CIA_lists/loc/ports.txt',
+    'region': '/home/eszter/CIA_lists/loc/region.txt',
+    'org': '/home/eszter/CIA_lists/org/org.txt',
+    'party': '/home/eszter/CIA_lists/org/party.txt',
+    'person': '/home/eszter/freebase_lists/pers/per_all'
+}
+
 
 class Featurizer(object):
-    def __init__(self, gazetteer_needed=False,
-                 fns={'languages': '/home/eszter/CIA_lists/misc/languages.txt',
-                      'religion': '/home/eszter/CIA_lists/misc/religion.txt',
-                      'ethnic': '/home/eszter/CIA_lists/misc/ethnic.txt',
-                      'nationality': '/home/eszter/CIA_lists/misc/nationality.txt',
-                      'capital': '/home/eszter/CIA_lists/loc/capital.txt',
-                      'city': '/home/eszter/CIA_lists/loc/city.txt',
-                      'country': '/home/eszter/CIA_lists/loc/countries.txt',
-                      'port': '/home/eszter/CIA_lists/loc/ports.txt',
-                      'region': '/home/eszter/CIA_lists/loc/region.txt',
-                      'org': '/home/eszter/CIA_lists/org/org.txt',
-                      'party': '/home/eszter/CIA_lists/org/party.txt',
-                      'person': '/home/eszter/freebase_lists/pers/per_all'}):
+    def __init__(self, gazetteer_needed=False, fns=None):
         self.feats = [
             case_feature,
             lasts, last_but_ones, last_but_twos
         ]
         if gazetteer_needed:
+            if fns is None:
+                fns = gaz_fns
             self.load_gazetteers(fns)
             for c in self.gazetteers:
-                self.feats.append(partial(gazetteer_feat, name=c, set_=self.gazetteers[c]))
+                self.feats.append(
+                    partial(gazetteer_feat, name=c, set_=self.gazetteers[c]))
         self.feat_num = len(self.feats)
 
     def load_gazetteers(self, fns):

--- a/hunvec/seqtag/sequence_tagger.py
+++ b/hunvec/seqtag/sequence_tagger.py
@@ -25,7 +25,7 @@ from hunvec.utils.fscore import FScCounter
 
 class SequenceTaggerNetwork(Model):
     def __init__(self, hdims, edim, fedim, dataset, w2i, t2i, featurizer,
-                 max_epochs=100, use_momentum=False, lr_decay=1.,
+                 max_epochs=100, use_momentum=False, lr=.01, lr_decay=1.,
                  valid_stop=False, reg_factors=None, dropout=False,
                  dropout_params=None, embedding_init=None):
         super(SequenceTaggerNetwork, self).__init__()
@@ -61,6 +61,7 @@ class SequenceTaggerNetwork(Model):
                                              self.n_classes))
         self.A = sharedX(A_value, name='A')
         self.use_momentum = use_momentum
+        self.lr = lr
         self.lr_decay = lr_decay
         self.valid_stop = valid_stop
         self.reg_factors = reg_factors
@@ -142,9 +143,9 @@ class SequenceTaggerNetwork(Model):
         self.dataset = data
         self.create_adjustors()
         term = EpochCounter(max_epochs=self.max_epochs)
-        cost_crit = MonitorBased(channel_name='valid_objective',
-                                 prop_decrease=0., N=10)
         if self.valid_stop:
+            cost_crit = MonitorBased(channel_name='valid_objective',
+                                     prop_decrease=.0, N=3)
             term = And(criteria=[cost_crit, term])
 
         #(layers, A_weight_decay)
@@ -160,7 +161,7 @@ class SequenceTaggerNetwork(Model):
                                          save_path=save_best_path)
 
         learning_rule = (self.momentum_rule if self.use_momentum else None)
-        self.algorithm = SGD(batch_size=1, learning_rate=0.01,
+        self.algorithm = SGD(batch_size=1, learning_rate=self.lr,
                              termination_criterion=term,
                              monitoring_dataset=data,
                              cost=cost,

--- a/hunvec/seqtag/sequence_tagger.py
+++ b/hunvec/seqtag/sequence_tagger.py
@@ -24,8 +24,9 @@ from hunvec.utils.fscore import FScCounter
 
 
 class SequenceTaggerNetwork(Model):
-    def __init__(self, hdims, edim, fedim, dataset, w2i, t2i, featurizer,
-                 max_epochs=100, use_momentum=False, lr=.01, lr_decay=1.,
+    def __init__(self, dataset, w2i, t2i, featurizer,
+                 edim=50, hdims=[100], fedim=5,
+                 max_epochs=100, use_momentum=False, lr=.01, lr_decay=.1,
                  valid_stop=False, reg_factors=None, dropout=False,
                  dropout_params=None, embedding_init=None):
         super(SequenceTaggerNetwork, self).__init__()
@@ -77,7 +78,6 @@ class SequenceTaggerNetwork(Model):
         d['window_size'] = self.window_size
         d['feat_num'] = self.feat_num
         d['n_classes'] = self.n_classes
-        d['max_epochs'] = self.max_epochs
         d['input_space'] = self.input_space
         d['output_space'] = self.output_space
         d['input_source'] = self.input_source
@@ -87,6 +87,14 @@ class SequenceTaggerNetwork(Model):
         d['w2i'] = self.w2i
         d['t2i'] = self.t2i
         d['featurizer'] = self.featurizer
+        d['max_epochs'] = self.max_epochs
+        d['use_momentum'] = self.use_momentum
+        d['lr'] = self.lr
+        d['lr_decay'] = self.lr_decay
+        d['valid_stop'] = self.valid_stop
+        d['reg_factors'] = self.reg_factors
+        d['dropout'] = self.dropout
+        d['dropout_params'] = self.dropout_params
         return d
 
     def fprop(self, data):

--- a/hunvec/seqtag/trainer.py
+++ b/hunvec/seqtag/trainer.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import argparse
 
 from pylearn2.utils import serial
@@ -17,21 +18,20 @@ def create_argparser():
     argparser = argparse.ArgumentParser()
     argparser.add_argument('dataset_file')
     argparser.add_argument('model_path')
-    argparser.add_argument('--hidden', default='100',
+    argparser.add_argument('--hidden',
                            help='comma separated integers, number of units' +
-                           'of hidden layers',
+                           'of hidden layers, default=100',
                            action=CSL2L)
-    argparser.add_argument('--embedding', default=50, type=int)
-    argparser.add_argument('--feat_embedding', default=5, type=int)
-    argparser.add_argument('--epochs', default=50, type=int)
-    argparser.add_argument('--regularization', default=.0, type=float,
+    argparser.add_argument('--embedding', type=int)
+    argparser.add_argument('--feat_embedding', type=int)
+    argparser.add_argument('--epochs', type=int)
+    argparser.add_argument('--regularization', type=float,
                            help='typical values are 1e-5, 1e-4')
     argparser.add_argument('--use_momentum', action='store_true'),
-    argparser.add_argument('--lr', default=.01, type=float,
-                           help='learning rate')
-    argparser.add_argument('--lr_decay', default=.1, type=float,
+    argparser.add_argument('--lr', type=float, help='learning rate')
+    argparser.add_argument('--lr_decay', type=float,
                            help='decrease ratio over time on learning rate')
-    argparser.add_argument('--valid_stop', type=bool, default=True,
+    argparser.add_argument('--valid_stop', action='store_true',
                            help='don\'t use valid data to decide when to stop')
     argparser.add_argument('--dropout_params', action=CSL2L,
                            help='use dropout on inner network' +
@@ -47,30 +47,35 @@ def init_network(args, dataset, corpus):
     if os.path.exists(args.model_path):
         # loading model instead of creating a new one
         wt = serial.load(args.model_path)
-        wt.max_epochs = args.epochs
-        wt.use_momentum = args.use_momentum
-        wt.lr = args.lr
-        wt.lr_decay = args.lr_decay
-        wt.valid_stop = args.valid_stop
-        wt.reg_factors = args.regularization
-        wt.dropout_params = args.dropout_params
-        wt.dropout = args.dropout or args.dropout_params is not None
-        return wt
+        if args.embedding or args.feat_embedding or args.hidden:
+            msg = "Dimensions and architecture cannot be changed "
+            msg += "when loading a model for further training"
+            logging.warning(msg)
+    else:
+        wt = SequenceTaggerNetwork(
+            dataset=dataset, w2i=corpus.w2i, t2i=corpus.t2i,
+            featurizer=corpus.featurizer,
+            edim=args.embedding, fedim=args.feat_embedding, hdims=args.hidden,
+            embedding_init=args.embedding_init)
 
-    wt = SequenceTaggerNetwork(edim=args.embedding, fedim=args.feat_embedding,
-                               hdims=args.hidden,
-                               dataset=dataset,
-                               w2i=corpus.w2i, t2i=corpus.t2i,
-                               featurizer=corpus.featurizer,
-                               max_epochs=args.epochs,
-                               use_momentum=args.use_momentum,
-                               lr=args.lr, lr_decay=args.lr_decay,
-                               valid_stop=args.valid_stop,
-                               reg_factors=args.regularization,
-                               dropout=args.dropout,
-                               dropout_params=args.dropout_params,
-                               embedding_init=args.embedding_init
-                               )
+    if args.epochs:
+        wt.max_epochs = args.epochs
+    if args.use_momentum:
+        wt.use_momentum = args.use_momentum
+    if args.lr:
+        wt.lr = args.lr
+    if args.lr_decay:
+        wt.lr_decay = args.lr_decay
+    if args.valid_stop:
+        wt.valid_stop = args.valid_stop
+    if args.regularization:
+        wt.reg_factors = args.regularization
+    if args.dropout_params:
+        wt.dropout_params = args.dropout_params
+        wt.dropout = True
+    elif args.dropout:
+        wt.dropout = args.dropout
+
     return wt
 
 


### PR DESCRIPTION
- arguments now don't have default values, because in continuation mode, we can't decide whether to change a parameter or not, because we don't know if a parameter is given or default
- this is why default values has been moved to `SequenceTaggerNetwork.__init__()`
- changed `__get_state__` to save all training params into model dump
- changed the way optional arguments (from argparse) change model's actual parameters in trainer.py